### PR TITLE
Removes second argument from all torch.Size()-calls.

### DIFF
--- a/storm_kit/mpc/control/olgaussian_mpc.py
+++ b/storm_kit/mpc/control/olgaussian_mpc.py
@@ -109,21 +109,21 @@ class OLGaussianMPC(Controller):
         # initialize sampling library:
         if sample_params['type'] == 'stomp':
             self.sample_lib = StompSampleLib(self.horizon, self.d_action, tensor_args=self.tensor_args)
-            self.sample_shape = torch.Size([self.num_nonzero_particles - 2], device=self.tensor_args['device'])
+            self.sample_shape = torch.Size([self.num_nonzero_particles - 2])
             self.i_ha = torch.eye(self.d_action, **self.tensor_args).repeat(1, self.horizon)
 
         elif sample_params['type'] == 'halton':
             self.sample_lib = HaltonSampleLib(self.horizon, self.d_action,
                                               tensor_args=self.tensor_args,
                                               **self.sample_params)
-            self.sample_shape = torch.Size([self.num_nonzero_particles - 2], device=self.tensor_args['device'])
+            self.sample_shape = torch.Size([self.num_nonzero_particles - 2])
         elif sample_params['type'] == 'random':
             self.sample_lib = RandomSampleLib(self.horizon, self.d_action, tensor_args=self.tensor_args,
                                               **self.sample_params)
-            self.sample_shape = torch.Size([self.num_nonzero_particles - 2], device=self.tensor_args['device'])
+            self.sample_shape = torch.Size([self.num_nonzero_particles - 2])
         elif sample_params['type'] == 'multiple':
             self.sample_lib = MultipleSampleLib(self.horizon, self.d_action, tensor_args=self.tensor_args, **self.sample_params)
-            self.sample_shape = torch.Size([self.num_nonzero_particles - 2], device=self.tensor_args['device'])
+            self.sample_shape = torch.Size([self.num_nonzero_particles - 2])
 
         self.stomp_matrix = None #self.sample_lib.stomp_cov_matrix
         # initialize covariance types:

--- a/storm_kit/mpc/control/sample_libs.py
+++ b/storm_kit/mpc/control/sample_libs.py
@@ -312,7 +312,7 @@ class MultipleSampleLib(SampleLib):
                 if(self.sample_ratio[k] == 0.0):
                     continue
                 n_samples = round(sample_shape[0] * self.sample_ratio[k])
-                s_shape = torch.Size([n_samples],**self.tensor_args)
+                s_shape = torch.Size([n_samples])
                 #if(k == 'halton' or k == 'random'):
                 samples = self.sample_fns[k](sample_shape=s_shape)
                 #else:
@@ -365,7 +365,7 @@ class HaltonStompSampleLib(SampleLib):
         halton_sample_size = list(sample_shape)
         halton_sample_size[0] = round(self.halton_ratio * halton_sample_size[0])
 
-        halton_samples = self.knot_sample_lib.get_samples(sample_shape=torch.Size(halton_sample_size,**self.tensor_args))
+        halton_samples = self.knot_sample_lib.get_samples(sample_shape=torch.Size(halton_sample_size))
         #halton_samples = self.halton_sample_lib.get_samples(sample_shape=torch.Size(halton_sample_size,**self.tensor_args), filter_smooth=False)
 
         # filter halton samples:
@@ -375,7 +375,7 @@ class HaltonStompSampleLib(SampleLib):
         
         stomp_sample_size = list(sample_shape)
         stomp_sample_size[0] = round(self.stomp_ratio * stomp_sample_size[0])
-        stomp_samples = self.stomp_sample_lib.get_samples(sample_shape=torch.Size(stomp_sample_size,**self.tensor_args))
+        stomp_samples = self.stomp_sample_lib.get_samples(sample_shape=torch.Size(stomp_sample_size))
         
         
         #sine_samples = self.sine_sample_lib.get_samples(sample_shape=torch.Size(stomp_sample_size,**self.tensor_args))


### PR DESCRIPTION
Addresses #3.
In newer version of pytorch `Size` does no longer allow the argument `device`.
This removes the argument in the corresponding files.